### PR TITLE
Update checks.js - Cross OS Compatible return handling

### DIFF
--- a/js/checks.js
+++ b/js/checks.js
@@ -106,7 +106,7 @@ function checklist_process() {
 async function checklist_load_file(checklist_file) { 
 	const checklist_obj = await fetch(checklist_file);
 	let checklist = await checklist_obj.text();
-	let checklist_array = checklist.split("\r\n");  
+  	let checklist_array = checklist.replace(/(\r\n|\n|\r)/gm, "|").split("|");
 	checklist_load_items(checklist_array);
 }
 


### PR DESCRIPTION
I had issues running this in mac, it turns out it doesn't handle returns the same way. the change replaces the two types of return (/r and /r/n) with a pipe which isn't commonly used in text, this in turn is used to split the file contents so this should work in windows and other OSs. I can't check windows today.